### PR TITLE
Fix struct and union array fields

### DIFF
--- a/src/ast.hh
+++ b/src/ast.hh
@@ -662,6 +662,10 @@ struct c_type: c_object {
         return arith() && (type() < C_BUILTIN_FLOAT);
     }
 
+    bool builtin_array() const {
+        return type() == C_BUILTIN_ARRAY;
+    }
+
     bool ptr_like() const {
         auto tp = type();
         return ((tp == C_BUILTIN_PTR) || (tp == C_BUILTIN_ARRAY));

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -21,6 +21,7 @@ test_cases = [
     ['abi example',                  'abi',                      false,   501],
     ['variadic calls',               'variadic',                 false,   501],
     ['structs, arrays, unions',      'struct_array',             false,   501],
+    ['structs, unions array fields', 'struct_union_array_fields',false,   501],
     ['memory-related utilities',     'copy_fill',                false,   501],
     ['callbacks',                    'callbacks',                false,   501],
     ['table initializers',           'table_init',               false,   501],

--- a/tests/struct_union_array_fields.lua
+++ b/tests/struct_union_array_fields.lua
@@ -1,0 +1,76 @@
+local ffi = require("cffi")
+
+ffi.cdef [[
+    struct foo {
+        uint8_t x;
+        uint32_t y;
+    };
+
+    struct bar {
+        uint8_t x[3];
+    };
+
+    struct baz {
+        uint32_t x;
+        uint8_t y[4];
+    };
+
+    struct baz_flex {
+        uint32_t x;
+        uint8_t y[2];
+        char z[];
+    };
+
+    struct qux {
+        uint32_t x;
+        /* pad 4 */
+        uint64_t y[2];
+        uint32_t z[2];
+    };
+
+    struct quux {
+        uint32_t x;
+        struct iquux {
+            uint8_t y[4];
+        } y[2];
+    };
+
+    struct quuux {
+        uint32_t x;
+        struct bar y;
+        struct quux z;
+    };
+
+    struct ufoo {
+        union {
+            uint32_t x;
+            uint64_t y[2];
+            uint32_t z[2];
+        };
+    };
+
+    struct ubar {
+        union {
+            uint8_t x[5];
+            int16_t y;
+        };
+    };
+]]
+
+assert(ffi.sizeof("struct foo") == 8)
+
+assert(ffi.sizeof("struct bar") == 3)
+
+assert(ffi.sizeof("struct baz") == 8)
+
+assert(ffi.sizeof("struct baz_flex") == 8)
+
+assert(ffi.sizeof("struct qux") == 32)
+
+assert(ffi.sizeof("struct quux") == 12)
+
+assert(ffi.sizeof("struct quuux") == 20)
+
+assert(ffi.sizeof("struct ufoo") == 16)
+
+assert(ffi.sizeof("struct ubar") == 6)


### PR DESCRIPTION
##### `fix fixed size array fields in structs and unions`

for a struct like:

```
struct foo {
    uint32_t x;
    uint8_t y[4];
};
```

`c_record::set_fields()` was populating the `ffi_type.elements` with
`[uint32_t, uint8_t *]`, which gives an incorrect structure size of 16
(4 bytes for `uint32_t`, 4 bytes for padding, 8 bytes for `uint_t *`)
after being prepared by `ffi_prep_cif()`.

this commit modifies `c_record::set_fields()` to expand fixed size array
types into separate elements in `ffi_type.elements`, e.g. [`uint32_t`,
`uint8_t`, `uint8_t`, `uint8_t`, `uint8_t`], as described in "2.3.4.1
Arrays" of the libffi documentation, so libffi can correctly calculate
the padding and size in `ffi_prep_cif()`.

it also updates the union size logic to use the total size of a fixed
size array field instead of the size of a pointer to the array base
type.

##### `factor out struct and union fields assignment`

this commit factors out the common `ffi_type.elements` assignment logic
from the union and struct code paths in `c_record::set_fields()`.