### PR TITLE
Fix global array variables and ffi.string() for flexible arrays

### DIFF
--- a/src/ffi.cc
+++ b/src/ffi.cc
@@ -527,8 +527,7 @@ int to_lua(
                 cd.val[0] = &cd.val[1];
                 return 1;
             }
-            newcdata<void *>(L, tp).val =
-                *reinterpret_cast<void * const *>(value);
+            newcdata<void const *>(L, tp).val = value;
             return 1;
         }
 

--- a/src/ffilib.cc
+++ b/src/ffilib.cc
@@ -1369,7 +1369,7 @@ struct ffi_module {
             default:
                 goto converr;
         }
-        if (ud.decl.type() == ast::C_BUILTIN_ARRAY) {
+        if (ud.decl.type() == ast::C_BUILTIN_ARRAY && ud.decl.alloc_size()) {
             char const *strp = static_cast<char const *>(*valp);
             /* arrays are special as they don't need to be null terminated */
             auto slen = ud.decl.alloc_size();

--- a/tests/dump_string.lua
+++ b/tests/dump_string.lua
@@ -40,3 +40,19 @@ local p =ffi.cast("struct foo const *", s)
 
 assert(ffi.string(s, ffi.sizeof(s)) == "abc")
 assert(ffi.string(p, ffi.sizeof(s)) == "abc")
+
+-- flexible array dump
+
+ffi.cdef [[
+    struct bar {
+        uint8_t x;
+        char s[];
+    };
+]]
+
+local b = ffi.new("char [5]", 0x10, 0x61, 0x62, 0x63, 0x00)
+local p = ffi.cast("struct bar const *", b)
+
+assert(p.x == 16)
+assert(ffi.string(p.s, 2) == "ab")
+assert(ffi.string(p.s) == "abc")

--- a/tests/lib_variables.lua
+++ b/tests/lib_variables.lua
@@ -1,0 +1,14 @@
+local ffi = require('cffi')
+
+ffi.cdef [[
+    const char test_string[];
+    const int test_ints[3];
+]]
+
+assert(ffi.C.test_string[0] == string.byte('f'))
+assert(ffi.C.test_string[1] == string.byte('o'))
+assert(ffi.C.test_string[2] == string.byte('o'))
+
+assert(ffi.C.test_ints[0] == 42)
+assert(ffi.C.test_ints[1] == 43)
+assert(ffi.C.test_ints[2] == 44)

--- a/tests/lib_variables.lua
+++ b/tests/lib_variables.lua
@@ -2,12 +2,18 @@ local ffi = require('cffi')
 
 ffi.cdef [[
     const char test_string[];
+    const char * const test_string_ptr;
     const int test_ints[3];
 ]]
+
+assert(ffi.string(ffi.C.test_string) == "foobar")
+assert(ffi.sizeof(ffi.C.test_string) == 0)
 
 assert(ffi.C.test_string[0] == string.byte('f'))
 assert(ffi.C.test_string[1] == string.byte('o'))
 assert(ffi.C.test_string[2] == string.byte('o'))
+
+assert(ffi.string(ffi.C.test_string_ptr) == "barbaz")
 
 assert(ffi.C.test_ints[0] == 42)
 assert(ffi.C.test_ints[1] == 43)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -24,6 +24,7 @@ test_cases = [
     ['structs, unions array fields', 'struct_union_array_fields', false,  501],
     ['memory-related utilities',     'copy_fill',                 false,  501],
     ['memory serialization',         'dump_string',               false,  501],
+    ['library variables',            'lib_variables',             false,  501],
     ['callbacks',                    'callbacks',                 false,  501],
     ['table initializers',           'table_init',                false,  501],
     ['parameterized types',          'parameterized',             false,  501],

--- a/tests/runner.cc
+++ b/tests/runner.cc
@@ -47,6 +47,12 @@ int test_add_ptr(int p[2]) {
 }
 
 extern "C" DLL_EXPORT
+const char test_string[] = "foobar";
+
+extern "C" DLL_EXPORT
+const int test_ints[3] = {42, 43, 44};
+
+extern "C" DLL_EXPORT
 int TEST_STDCALL test_stdcall(int a, int b) {
     return a + b;
 }

--- a/tests/runner.cc
+++ b/tests/runner.cc
@@ -50,6 +50,9 @@ extern "C" DLL_EXPORT
 const char test_string[] = "foobar";
 
 extern "C" DLL_EXPORT
+const char * const test_string_ptr = "barbaz";
+
+extern "C" DLL_EXPORT
 const int test_ints[3] = {42, 43, 44};
 
 extern "C" DLL_EXPORT


### PR DESCRIPTION
#### `fix global array variables`

the cdata object created for global arrays was dereferencing the library
symbol instead of treating it as a pointer. this causes a segfault when
the array is accessed by the user and dereferenced a second time.

I made this modification to the `to_lua()` code path, which is called from `get_global()`, but I'm not sure if code path is used in other contexts where a builtin array should be handled differently.

#### `fix ffi.string() for flexible arrays`

`ffi_module::string_f()` limits serialization of the `C_BUILTIN_ARRAY`
to `decl.alloc_size()` length, which is 0 for flexible arrays and
results in the empty string. this commit changes flexible arrays to be
treated as null-terminated char pointers.