### PR TITLE
src/platform.hh: fix or1k build

### DIFF
--- a/src/platform.hh
+++ b/src/platform.hh
@@ -192,7 +192,7 @@
 #  endif
 #elif defined(__OR1K__)
 #  define FFI_ARCH FFI_ARCH_OR1K
-#  define FFO_ARCH_NAME "or1k"
+#  define FFI_ARCH_NAME "or1k"
 #elif defined(__riscv) || defined(__riscv__)
 #  if __riscv_xlen == 32
 #    define FFI_ARCH FFI_ARCH_RV32


### PR DESCRIPTION
Fix the following or1k build failure raised since version 0.2.2 and https://github.com/q66/cffi-lua/commit/27755f61e4c625dff951302bade4ad07e3609ca5:

```
In file included from /home/buildroot/autobuild/run/instance-0/output-1/host/or1k-buildroot-linux-uclibc/sysroot/usr/include/lua.hpp:6,
                 from ../src/lua.hh:23,
                 from ../src/parser.hh:4,
                 from ../src/ffilib.cc:7:
../src/ffilib.cc: In static member function 'static void ffi_module::setup(lua_State*)': ../src/ffilib.cc:1616:28: error: expected ')' before 'FFI_ARCH_NAME'
 1616 |         lua_pushliteral(L, FFI_ARCH_NAME);
      |                            ^~~~~~~~~~~~~
```

Fixes: 27755f61e4c625dff951302bade4ad07e3609ca5
 - http://autobuild.buildroot.org/results/4e14753732c5b6fe8ba9ecc4050ffb35f471c428